### PR TITLE
Update tbdollars to reflect units from subunits

### DIFF
--- a/src/apiUtils.ts
+++ b/src/apiUtils.ts
@@ -70,7 +70,7 @@ export async function getTBDollars(didState, topup?: boolean) {
         'Authorization': 'Bearer ' + token
       }
     })
-    return await res.json()
+    return (await res.json()).balance / 100
   } catch (e) {
     throw new Error(e)
   }

--- a/src/features/Balance.tsx
+++ b/src/features/Balance.tsx
@@ -12,14 +12,21 @@ export function Balance() {
   useEffect(() => {
     const init = async () => {
       try {
-        const res = await getTBDollars(did)
-        setAccountBalance(res.balance)
+        const balance = await getTBDollars(did)
+        setAccountBalance(balance)
       } catch {
         setAccountBalance(null)
       }
     }
     void init()
   }, [])
+
+  async function addFunds() {
+    const balance = await getTBDollars(did, true)
+    if (balance) {
+      setAccountBalance(balance)
+    }
+  }
   
   return (
     <>
@@ -33,7 +40,7 @@ export function Balance() {
       ) : (
         <>
           <div className="mt-2 mb-3 text-3xl font-semibold text-gray-200">{TBD(accountBalance).format()}</div>
-          <button className='rounded-md bg-indigo-600 p-2 text-white' onClick={() => getTBDollars(did, true)}>Add funds</button>
+          <button className='rounded-md bg-indigo-600 p-2 text-white' onClick={addFunds}>Add funds</button>
         </>
       )}
     </>

--- a/src/features/ExchangeModalUtils.tsx
+++ b/src/features/ExchangeModalUtils.tsx
@@ -16,9 +16,9 @@ export const renderActionButtons = (amount, exchangeId, onClose, didState) => {
       setIsUpdating(true)
       try {
         await createOrder({ exchangeId, didState })
-        const res = await getTBDollars(did)
-        if (accountBalance !== res.balance) {
-          setAccountBalance(res.balance)
+        const balance = await getTBDollars(did)
+        if (accountBalance !== balance) {
+          setAccountBalance(balance)
         }
       } catch (e) {
         setIsUpdating(false)


### PR DESCRIPTION
This PR ensures tbdollars returned are rendered as units instead of subunits, ie. $5 instead of $500 